### PR TITLE
docs: add Velantrim Cognitive System Vision v0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,5 @@
 
 ## Ecosystem documentation
 
+- [Velantrim Cognitive System Vision v0.1](docs/vision/VELANTRIM_COGNITIVE_SYSTEM_VISION.md) — desired human-facing cognitive capabilities and North Star. Vision only; not architecture, runtime, or authority.
 - [Velantrim Knowledge Semantics v0.1](docs/knowledge/VELANTRIM_KNOWLEDGE_SEMANTICS.md) — cross-project vocabulary for Stability, Variance, Practicality, Perspective, and Purpose. Descriptive only; not a runtime or authority domain.

--- a/docs/vision/VELANTRIM_COGNITIVE_SYSTEM_VISION.md
+++ b/docs/vision/VELANTRIM_COGNITIVE_SYSTEM_VISION.md
@@ -1,0 +1,420 @@
+# 🧠 Velantrim Cognitive System Vision v0.1
+
+**Status:** 🌱 IDEA / VISION  
+**Authority:** Descriptive only. Not a technical specification, runtime design, implementation plan, Canon, or authority grant.  
+**Scope:** Defines the desired human-facing cognitive capabilities of the Velantrim ecosystem before capability audit, architecture selection, or implementation.
+
+---
+
+## 🎯 1. North Star
+
+Velantrim should feel like one coherent cognitive process to the user, even if many independent projects and mechanisms exist internally.
+
+The user should not need to know which project, memory tier, retrieval mechanism, reasoning mode, or tool is responsible for a task.
+
+The desired sequence is:
+
+```text
+👤 Human / World
+      ↓
+🧠 Understand what is happening
+      ↓
+🔎 Determine what is needed
+      ↓
+🧩 Select the capabilities that can help
+      ↓
+📚 Recall / retrieve / connect relevant knowledge
+      ↓
+❓ Identify gaps and questions
+      ↓
+💭 Reason / verify / compare
+      ↓
+💬 Respond or propose action
+      ↓
+🔐 Authority check when action or trusted mutation is involved
+      ↓
+🧠 Update working state and memory when justified
+```
+
+**Primary design principle:** first determine **what is needed**, then determine **what in the system can do it**.
+
+---
+
+## 🧠 2. Meaning and Context
+
+The system should attempt to build a structured understanding of incoming information rather than treat interaction as isolated text.
+
+It should identify, where possible:
+
+- topic and entities;
+- relationships;
+- facts, hypotheses, questions, intentions, and preferences;
+- current and historical context;
+- ambiguity and missing information;
+- relevant scope and time;
+- possible implications and conflicts.
+
+The system may infer possible meaning, but inference must remain distinguishable from observation.
+
+```text
+interpretation != fact
+inferred intent != declared intent
+model of meaning != absolute understanding
+```
+
+---
+
+## 💾 3. Memory
+
+The system should support multiple memory horizons rather than one undifferentiated store.
+
+Candidate functional levels:
+
+- ⚡ **Immediate / Active State** — what matters right now;
+- 📝 **Working Memory** — information needed for the current task;
+- ⏳ **Temporary Memory** — useful short-lived context;
+- 🧩 **Intermediate / Consolidation State** — candidates for durable retention;
+- 📚 **Long-Term Memory** — durable knowledge, events, preferences, decisions, and learned context;
+- 🏛️ **Trusted / Canonical Memory** — information subject to stronger provenance, admission, integrity, and mutation rules.
+
+The system should be able to ask:
+
+- What should be retained?
+- For how long?
+- Why?
+- What should be linked to existing memory?
+- What is obsolete or superseded?
+- What must not be promoted automatically?
+
+```text
+memory != truth
+remembered != verified
+recent != true
+frequent != important
+long-term != immutable
+```
+
+---
+
+## 🔎 4. Retrieval and Information Extraction
+
+Having memory is insufficient; the system must retrieve the right information for the current goal.
+
+Retrieval should be guided by meaning, context, time, relationships, current goals, provenance, contradictions, and uncertainty where available.
+
+Desired flow:
+
+```text
+QUESTION / GOAL
+      ↓
+INTENT + CONTEXT
+      ↓
+WHAT INFORMATION IS NEEDED?
+      ↓
+RETRIEVAL
+      ↓
+CANDIDATES
+      ↓
+EVALUATION
+      ↓
+USEFUL CONTEXT
+```
+
+```text
+retrieved != relevant
+relevant != true
+similar != identical
+high-ranked != authoritative
+```
+
+---
+
+## 🔗 5. Meaningful Relations
+
+The system should progressively connect information into a usable contextual model.
+
+Examples of useful relations include:
+
+- supports;
+- challenges;
+- qualifies;
+- supersedes;
+- depends on;
+- causes / may cause;
+- part of;
+- similar to;
+- relevant to a current goal;
+- contradicts a previous assumption.
+
+Repeated interaction should allow broader patterns to emerge, such as stable design preferences or recurring goals, while preserving uncertainty and revisability.
+
+```text
+association != truth
+correlation != causation
+repetition != automatic belief
+inferred preference != permanent identity
+```
+
+---
+
+## ❓ 6. Questions and Epistemic Gaps
+
+The system should not only answer questions. It should be able to detect when its current understanding is incomplete.
+
+Examples:
+
+- a missing link between two known facts;
+- conflicting evidence;
+- unclear scope;
+- uncertain intent;
+- outdated information;
+- a conclusion that depends on an unverified premise.
+
+Desired loop:
+
+```text
+OBSERVE
+  ↓
+INTERPRET
+  ↓
+WHAT IS MISSING OR UNCLEAR?
+  ↓
+QUESTION
+  ↓
+SEARCH / REASON / ASK
+  ↓
+UPDATED UNDERSTANDING
+```
+
+A question may be directed to the user, memory, external evidence, another bounded reasoning process, or an internal consistency check.
+
+```text
+self-questioning != independent evidence
+second reasoning pass != independent reviewer
+internal answer != fact
+```
+
+---
+
+## 👤 7. Progressive User Understanding
+
+With continued interaction, the system should reduce unnecessary repetition by retaining useful context about the person and ongoing work.
+
+Examples:
+
+- current projects and goals;
+- terminology;
+- preferred level of detail;
+- accepted and rejected approaches;
+- recurring constraints;
+- long-running decisions and open questions;
+- communication preferences.
+
+This context must remain revisable.
+
+```text
+past preference != permanent preference
+old goal != current goal
+inferred trait != identity fact
+repeated behavior != permission
+```
+
+---
+
+## ❤️ 8. Emotion, Affect, and Human Context
+
+The system should be able to account for emotional and relational context where it is relevant to interaction, attention, memory, or interpretation.
+
+It may detect signals such as uncertainty, frustration, enthusiasm, hesitation, urgency, or emotional importance, but these remain attributed interpretations unless explicitly confirmed.
+
+```text
+emotion inference != emotion fact
+emotion != truth signal
+emotion != authority
+emotional relevance != objective importance
+```
+
+The goal is not to claim human subjective experience. The goal is to interact more appropriately with the human context surrounding information and decisions.
+
+---
+
+## 💭 9. Reasoning
+
+The system should be able to perform bounded internal reasoning appropriate to the task.
+
+Typical questions include:
+
+1. What was said or observed?
+2. What is likely being asked?
+3. What is already known?
+4. What is missing?
+5. Are there contradictions?
+6. What needs retrieval or verification?
+7. What alternative explanations exist?
+8. What is best supported?
+9. How uncertain is the conclusion?
+10. What can be answered now?
+11. What, if anything, should be retained?
+
+This does not require one universal reasoning engine. Different reasoning families may be composed as needed.
+
+---
+
+## 🌱 10. Learning and Development
+
+The system should become more useful over time without requiring every improvement to modify model weights.
+
+Development may come from:
+
+- better memory;
+- better relations;
+- better retrieval;
+- corrected prior conclusions;
+- better user/context models;
+- improved procedures;
+- accumulated evidence;
+- better questions;
+- improved task continuity.
+
+The key test is simple:
+
+> After sustained interaction, can the system continue the work with better context, fewer unnecessary repetitions, and more accurate use of prior knowledge than on the first day?
+
+```text
+learning != truth
+adaptation != identity mutation
+experience != authority
+```
+
+---
+
+## ⚙️ 11. Hidden Internal Complexity
+
+Velantrim may contain many specialized projects, but the user-facing cognitive process should remain simple.
+
+```text
+👤 “Here is my task.”
+        ↓
+🧠 “What is needed?”
+        ↓
+🧩 “Which capabilities can provide it?”
+        ↓
+✅ Result
+```
+
+Users should not have to manually choose internal projects or know their authority boundaries.
+
+Internal separation can remain strict while the human-facing experience remains coherent.
+
+---
+
+## 🌐 12. High-Level Cognitive Cycle
+
+```text
+                    👤 HUMAN / WORLD
+                           │
+                           ▼
+                    👁 PERCEPTION
+                           │
+                           ▼
+                    🧠 MEANING
+                           │
+                  ┌────────┼─────────┐
+                  │        │         │
+                  ▼        ▼         ▼
+              📚 MEMORY  🔎 SEARCH  🔗 RELATIONS
+                  │        │         │
+                  └────────┼─────────┘
+                           ▼
+                    🧩 CONTEXT MODEL
+                           │
+                           ▼
+                    ❓ QUESTIONS
+                           │
+                           ▼
+                    💭 REASONING
+                           │
+             ┌─────────────┼─────────────┐
+             ▼             ▼             ▼
+        📌 FACTS       ❤️ CONTEXT     🎯 GOALS
+             │             │             │
+             └─────────────┼─────────────┘
+                           ▼
+                     🧠 UNDERSTANDING
+                           │
+                           ▼
+                       💬 RESPONSE
+                           │
+                           ▼
+                     ⚙️ POSSIBLE ACTION
+                           │
+                           ▼
+                     🔐 AUTHORITY CHECK
+                           │
+                           ▼
+                     🌍 WORLD / HUMAN
+
+                           ↕
+                     🧠 MEMORY UPDATE
+```
+
+---
+
+## 🚫 13. Non-Claims
+
+This Vision does **not** assert that:
+
+- the system is conscious;
+- it possesses human subjective experience;
+- it literally feels emotions;
+- one AI process should own all authority;
+- all Velantrim projects should be merged;
+- one universal model or database is required;
+- the existing architecture already satisfies the Vision;
+- every capability described here should be implemented immediately;
+- a new central Kernel, runtime, or authority domain is required.
+
+This document defines desired capabilities, not their implementation.
+
+---
+
+## 🔬 14. Next Step: Capability Audit
+
+The next question should not be “What do our projects currently do?” in isolation.
+
+The audit question should be:
+
+> Given this Vision, how much of each desired capability can the current Velantrim projects already provide individually or collectively?
+
+For each capability, the audit should classify:
+
+- ✅ already implemented;
+- 🟡 partially implemented;
+- 🔬 present as research/specification only;
+- 🔗 requires bounded composition of multiple projects;
+- ❌ absent;
+- 🧹 duplicated or unnecessarily complex;
+- ⚠️ present but semantically or architecturally misplaced.
+
+Only after that audit should Velantrim decide what to test, simplify, compose, remove, or build.
+
+---
+
+## 🌟 Summary
+
+Velantrim should optimize for the smallest set of capabilities sufficient for a coherent long-lived cognitive process:
+
+```text
+ПОНЯТЬ
+→ ВСПОМНИТЬ
+→ НАЙТИ
+→ СВЯЗАТЬ
+→ СПРОСИТЬ
+→ ПОДУМАТЬ
+→ ОТВЕТИТЬ
+→ СОХРАНИТЬ
+→ НАУЧИТЬСЯ
+→ ПРОДОЛЖИТЬ
+```
+
+The complexity of internal projects should remain hidden behind this simple cognitive loop, while evidence, identity, semantics, memory, authority, and execution remain properly separated.


### PR DESCRIPTION
## Summary

Adds the ecosystem-level Cognitive System Vision v0.1 under `docs/vision/` and links it from the repository README.

The document defines the desired human-facing cognitive capabilities before capability audit or architecture selection: meaning/context, memory horizons, retrieval, semantic relations, questions, reasoning, progressive user understanding, affect-aware context, learning, and hidden internal complexity.

## Boundaries

- Vision only; not a technical specification or implementation plan.
- Does not create a new runtime, authority domain, Canon, database, or central Kernel.
- Does not assign implementation ownership to existing projects.
- Explicitly preserves distinctions such as memory != truth, retrieval != evidence, and inferred context != authority.

## Next step

Use the Vision as the evaluation surface for a separate cross-project Capability Audit before deciding what to test, simplify, compose, remove, or build.