### PR TITLE
docs: add Velantrim ecosystem master map

### DIFF
--- a/docs/architecture/VELANTRIM_ECOSYSTEM_MASTER_MAP.md
+++ b/docs/architecture/VELANTRIM_ECOSYSTEM_MASTER_MAP.md
@@ -1,0 +1,391 @@
+# 🗺️ Velantrim Ecosystem Master Map ⚙️
+
+**Status:** MASTER SYNTHESIS / ORIENTATION / RESEARCH BRIDGE  
+**Authority:** documentation only; not runtime authority, not a new Canon root, not an integration authorization.
+
+> Freshness rule: for volatile state, live GitHub and each project's own current-state / governance documents win. This map does not transfer authority between repositories.
+
+## 1. What Velantrim is
+
+Velantrim is an ecosystem of independent but potentially composable systems. Responsibilities are deliberately separated across operation, memory/evidence, cognition/identity, semantic invariants, process continuity, composition rules, reusable AI methods, and cognitive research.
+
+```text
+🤖 inference/model        = replaceable computation
+🔱 operation              = orchestration and execution
+💠 memory/evidence        = verifiable memory, provenance, bounded Canon admission
+🌀 cognition              = beliefs, self/identity, working cognitive models
+🌎 continuity             = process survival across model/context replacement
+🧬 semantics              = substrate-neutral invariants and meaning contracts
+🪁 composition            = safe cross-domain composition / non-escalation
+🧩 Skills                 = reusable AI work methods
+⚗️ Cognitive Life OS     = research blueprint for cognition
+```
+
+### Core non-conflation rules
+
+```text
+research ≠ runtime
+spec ≠ implementation
+implemented ≠ wired
+wired ≠ enabled
+enabled ≠ production authority
+retrieval ≠ evidence
+evidence ≠ belief
+belief ≠ truth
+claim ≠ identity
+proposal ≠ admitted state
+model confidence ≠ authority
+integration ≠ authority transfer
+receipt ≠ truth
+UNKNOWN ≠ false
+```
+
+## 2. Responsibility map
+
+| Surface | Primary responsibility | Must not silently become |
+|---|---|---|
+| 🔱 Velantrim Exo-Cortex Titan | orchestration, providers/models, tools, capability/runtime lifecycle, execution host | truth authority, Crystal Canon owner, identity authority |
+| 💠 Velantrim Exo-Cortex Crystal | local-first memory, claims/evidence/provenance, epistemic boundaries, bounded Canon admission, recovery/receipts | global cognition engine, identity owner, unrestricted action runtime |
+| 🧬 Velantrim Native Kernel | substrate-neutral semantics, invariants, falsifiable contracts, portability of meaning | runtime coordinator, universal TruthGate, production agent |
+| 🌀 Velantrim Mentaury Soul | cognition, beliefs/claims, self/non-self, identity/relationships, reflection, hypothesis discrimination | Crystal evidence authority, unrestricted action authority |
+| 🌎 Velantrim Continuum / IDPS | durable process continuity, capture/handoff/rehydration, task continuation across inference/context changes | memory Canon, cognition engine, hidden runtime authority |
+| 🪁 Mentaury-Kernel | cross-domain composition, compatibility, provenance crossing, authority non-escalation | third brain, scheduler, central runtime coordinator |
+| 🧩 velantrim-ai-skills | project-neutral AI methodologies, roles, Skills, checklists, templates | authority over a target project |
+| 🧭 Knowledge Atlas | ecosystem navigation and source routing | live runtime-state authority |
+| ⚗️ Velantrim Cognitive Life OS | research blueprint for cognitive mechanics, reasoning operators, model revision, inquiry, measurement-first work | apex authority root, production runtime, proven universal theory of mind |
+| 🧠 Velantrim System OS | current/research bridge and system-level orientation | automatically authorized shared runtime |
+| 🧠 Velantrim-Version-LLM-AI-Cognitive-OS | existing cognitive/research surface; exact authority comes from its own docs | assumed integrated cognitive runtime |
+| 🏛️ velantrian/velantrim | umbrella/root repository for cross-project documentation | automatic inheritance of authority from or over child projects |
+
+This is a responsibility map, not an authority hierarchy and not a claim that all components are currently wired together.
+
+## 3. Conceptual future composition
+
+```text
+                         👤 HUMAN
+                            │
+                            ▼
+                 🧩 Skill / Method Layer
+                            │
+                            ▼
+                 🧠 Cognitive Inquiry
+                 models / hypotheses / tests
+                            │
+                            ▼
+                       🔱 TITAN
+               orchestration / execution
+                            │
+          ┌─────────────────┼─────────────────┐
+          ▼                 ▼                 ▼
+     💠 CRYSTAL        🌎 CONTINUUM       🌀 SOUL
+ memory/evidence       process state       cognition
+ provenance/trace       continuity          beliefs
+          │                 │                 │
+          └─────────────────┼─────────────────┘
+                            │
+                    🪁 COMPOSITION RULES
+                     Mentaury-Kernel
+                            │
+                            ▼
+                    🧬 NATIVE SEMANTICS
+                            │
+                            ▼
+                     🛡️ ADMISSION
+                            │
+                            ▼
+                 🌍 BOUNDED EXTERNAL ACTION
+```
+
+**Key rule:** inference may propose, search, reason, revise, and generate candidates, but `candidate ≠ permission`.
+
+## 4. Cross-project authority model
+
+```text
+Candidate / Proposal
+        ↓
+AdmissionRequest
+        ↓
+Target-domain validation
+        ↓
+   ┌────┴────┐
+   ▼         ▼
+ DENY       ALLOW
+   │          │
+Decision   CapabilityLease
+Receipt      │
+             ▼
+       bounded operation
+             │
+             ▼
+      ConsumptionReceipt
+```
+
+Separate three things:
+
+- **Cognitive freedom** — form and destroy hypotheses, compare alternatives, reframe working models.
+- **State authority** — what may enter durable or authoritative state.
+- **Action authority** — what external actions are allowed.
+
+High cognitive autonomy does not imply high action authority.
+
+## 5. Skills layer
+
+`velantrian/velantrim-ai-skills` is project-neutral external AI tooling. Its intended role is reusable methodology, not persistent truth or project authority.
+
+```text
+🧩 Skill
+   ↓ method / procedure
+🧠 cognitive or reasoning service
+   ↓ uses
+🗃 state + 📚 evidence + 🔌 tools
+```
+
+### Candidate: Cognitive Inquiry Skill v0
+
+A future reusable Skill may require an AI to:
+
+1. separate `intent / goal / hypothesis / plan / constraints`;
+2. treat the user's starting hypothesis as **UNVERIFIED**, not truth;
+3. generate compact competing hypotheses plus `UNKNOWN/OTHER`;
+4. search for contradictions;
+5. choose the next discriminating question/test;
+6. update the working model from evidence;
+7. explain why the decision changed;
+8. check alignment with current authorized intent;
+9. obey the target project's authority rules.
+
+An adaptive Skill should guide a stateful loop; the Skill file itself should not silently self-rewrite or become the durable belief store.
+
+## 6. Managed attention research
+
+The key research question is:
+
+> How should a system choose the next cognitive operation or observation from current intent, working model, evidence, and uncertainty so that the next step most improves the decision?
+
+### Task state
+
+```text
+📜 OriginalIntent
+      ↓ historically preserved
+🧭 CurrentAuthorizedIntent
+      ↓ owner may explicitly change it
+🎯 WorkingGoal
+      ↓ revisable within intent
+💭 Hypotheses + UNKNOWN
+      ↓
+🔬 Evidence / Experiment
+      ↓
+🛠 Plan / Action candidate
+```
+
+A user's first explanation is `USER-PROPOSED HYPOTHESIS`, not a fact and not automatically privileged.
+
+## 7. Cognitive loop
+
+```text
+🧭 Intent
+   ↓
+🧠 Working Model
+   ↓
+💭 Competing Hypotheses + UNKNOWN
+   ↓
+🎛️ Attention / Reasoning Operators
+   ↓
+🔬 Best Next Inquiry
+   ↓
+📚 Evidence
+   ↓
+⚖️ Belief Update
+   ↓
+┌─────────────────────────────┐
+│ model explains the data?    │
+└────────────┬────────────────┘
+        YES  │  NO
+             │
+      continue     ⚠️ MODEL-SET FAILURE
+                         ↓
+                 rebuild hypothesis space
+                         ↓
+                  🔄 new working model
+                         ↓
+                  🧭 intent alignment
+```
+
+Attention should not degrade into top-k similarity alone. Candidate signals include:
+
+- relevance to intent/goal;
+- uncertainty;
+- contradiction pressure;
+- decision leverage;
+- diversity across explanatory families;
+- novelty;
+- redundancy penalty.
+
+## 8. Choosing the next experiment
+
+The goal is not maximum belief movement for its own sake. The better criterion is expected decision improvement.
+
+```text
+ValueOfInformation(test)
+≈ expected best utility after observing test
+ - best utility with current evidence
+ - cost
+ - risk
+ - delay
+```
+
+The practical question is:
+
+> What is most valuable to learn next in order to reduce decision error?
+
+If every active model explains new evidence poorly, the system should be able to return `UNKNOWN` and rebuild the hypothesis space rather than forcing a bad winner.
+
+## 9. Decision / Evidence Trace
+
+Prefer structured traces over storing unrestricted inner monologue.
+
+```text
+Hypothesis: H2 soil problem
+Evidence: E17 soil analysis
+Prediction mismatch: H1 water-only explanation weakened
+belief: H1 0.30 → 0.08
+status: CONTRADICTED
+next inquiry: E4
+reason: higher expected value / lower regret
+intent check: PASS
+```
+
+The objective is to preserve inspectable reasons for revision without turning free-form model internals into authority.
+
+## 10. COG-EXP-001
+
+**Status:** proposed research experiment only.
+
+Hypothesis to test:
+
+> A system with competing hypotheses, `UNKNOWN`, decision-directed inquiry, and model revision produces better bounded decisions after a false initial hypothesis than an ordinary LLM or LLM+retrieval baseline.
+
+### Minimal setup
+
+- one narrow synthetic world;
+- known hidden cause;
+- 3–7 active hypotheses plus UNKNOWN;
+- limited investigation budget (for example 3 tests);
+- fixed costs, risks, and reliabilities;
+- fully observable decision/evidence trace.
+
+### Comparison
+
+```text
+A — ordinary LLM
+B — LLM + retrieval/RAG
+C — LLM + hypotheses + information gain
+D — VOI + UNKNOWN + model revision + intent guardian
+```
+
+### Metrics
+
+- final decision utility;
+- number of tests used;
+- investigation cost;
+- recovery from false starting hypothesis;
+- UNKNOWN / model-set-failure detection;
+- intent preservation;
+- regret;
+- revision accuracy.
+
+### Falsification rule
+
+If D does not produce stable measurable benefit, do not expand architecture merely because the mechanism appears intellectually elegant.
+
+## 11. Autonomous and Jarvis modes
+
+One cognitive core may support two policy profiles.
+
+```text
+                  🧠 SAME COGNITIVE CORE
+                         │
+             ┌───────────┴───────────┐
+             ▼                       ▼
+      🤖 AUTONOMOUS              🧑‍🤝‍🧑 JARVIS
+```
+
+They should differ primarily by:
+
+```text
+interruption policy
+approval policy
+action budget
+escalation threshold
+```
+
+not by having completely separate intelligence architectures.
+
+## 12. Where new work belongs
+
+| New concern | Likely current home | Do not do |
+|---|---|---|
+| 🧪 COG-EXP-001 | Cognitive Life OS / existing Cognitive-OS research surface after reading its own authority docs | do not auto-create another major repo |
+| 🧩 Cognitive Inquiry Skill v0 | `velantrim-ai-skills` after separate Skill validation | do not store persistent truth/state there |
+| 📚 Evidence/provenance | potentially Crystal through its admission semantics | do not write research candidates directly into Canon |
+| 💭 Working beliefs/hypotheses | potentially Soul | do not transfer Crystal truth authority into Soul |
+| 🔌 Experiment/tool execution | potentially Titan | orchestration is not truth authority |
+| 🔄 Long-running inquiry state | potentially Continuum | handoff is not truth/memory admission |
+| 🧬 Semantic distinctions | Native Kernel after evidence | do not generalize one experiment into universal law |
+| 🪁 Cross-project exchange | Mentaury-Kernel composition/non-escalation | do not define giant universal envelopes without concrete need |
+
+## 13. Existing versus candidate state
+
+### Existing surfaces
+
+- six primary repositories with distinct responsibility and authority boundaries;
+- Knowledge Atlas and ecosystem orientation documents;
+- Velantrim System OS documentation surface;
+- Velantrim Cognitive Life OS in documentation;
+- `velantrim-ai-skills` with AI entry, roles, and audit methodology;
+- `Velantrim-Version-LLM-AI-Cognitive-OS` repository;
+- managed-attention / next-experiment research material.
+
+### Do not yet treat as proven integrated runtime
+
+- stateful Cognitive Inquiry Core;
+- production VOI planner;
+- universal UNKNOWN/model-set-failure runtime;
+- end-to-end Intent Guardian;
+- production unified Autonomous/Jarvis core;
+- Cognitive Inquiry Skill v0;
+- COG-EXP-001 positive result;
+- production cross-project wiring of the cognitive loop.
+
+## 14. Recommended order
+
+1. Maintain this Master Map as an orientation surface.
+2. Specify COG-EXP-001 with explicit hypothesis, world, budgets, metrics, and falsification criteria.
+3. Run A/B/C/D benchmark without premature project integration.
+4. Review evidence.
+5. If justified, implement and validate `Cognitive Inquiry Skill v0` as a reusable method/interface.
+6. Write an Integration RFC assigning ownership for every state/action boundary.
+7. Run shadow/bounded integration without production authority.
+8. Admit runtime changes only through project-specific evidence and approval.
+
+## 15. Do not do now
+
+- Do not merge all projects into a monorepo for conceptual neatness.
+- Do not create a new central brain that owns truth + identity + memory + action.
+- Do not promote Cognitive Life OS or System OS to an authority apex.
+- Do not treat a Skill as memory, belief storage, or authority.
+- Do not let trust score expand authority classes by itself.
+- Do not accept the user's initial hypothesis as fact.
+- Do not force a hypothesis choice when the correct state is UNKNOWN.
+- Do not confuse cognitive boldness with external action freedom.
+- Do not integrate COG-EXP-001 into Titan/Crystal/Soul before measuring it.
+
+## 16. One-line synthesis
+
+> Velantrim should let inference freely construct and destroy working models, while converting hypotheses into durable truth/state or external action only through evidence, explicit domain boundaries, and bounded authority.
+
+The new cognitive research adds one further question:
+
+> How do we select not the most similar fact, but the next piece of knowledge or observation most likely to improve the decision while remaining aligned with human intent?
+
+**Next falsifiable checkpoint:** `COG-EXP-001`.


### PR DESCRIPTION
Adds a cross-project orientation document that maps responsibilities across Titan, Crystal, Native Kernel, Mentaury Soul, Continuum, Mentaury-Kernel, AI Skills, System OS, Cognitive Life OS, and related research surfaces.

Boundaries:
- documentation only
- no runtime authorization
- no authority transfer
- no monorepo/integration change
- COG-EXP-001 and Cognitive Inquiry Skill v0 remain research candidates

The document explicitly preserves project-local authority and live-state precedence.